### PR TITLE
WIP: CAN communication with BBB for MPPT

### DIFF
--- a/include/mppt.h
+++ b/include/mppt.h
@@ -1,7 +1,13 @@
 #include "mbed.h"
 #define MPPT_BASE_ID 0x0000
 #define MPPT_MODE_ID MPPT_BASE_ID + 8 // mode
-#define MPPT_MCC_ID MPPT_BASE_ID + 11 // max charge current
+#define MPPT_MOV_ID MPPT_BASE_ID + 10 // max output voltage
+#define MPPT_MOC_ID MPPT_BASE_ID + 11 // max output current
+
+#define SAMPLE_SIZE 5
+#define CALC_INTERVAL 10
+#define TRACKING_DELAY 20
+#define MPPT_STEP 0.1
 
 /* This is a struct
  * which holds a generic typed value
@@ -25,21 +31,18 @@ struct mutexVar {
       value = tmp;
       mutex.unlock();
     }
-    /* reading a variable
-     * doesn't require a
-     * mutex lock and unlock
-     *
-     * but the value is private
-     * so it can only be changed
-     * via setValue, utilizing the mutex
-     */
     T getValue(void) {
+      mutex.lock();
       return value;
+      mutex.unlock();
     }
 };
 
 class BoostConverter {
   private:
+    bool direction = true;
+    float last_power = 0; // previous power
+    float v_ref = 48; // voltage we want
     PwmOut pwm;
     AnalogIn voltageADC;
     AnalogIn currentADC;
@@ -47,25 +50,32 @@ class BoostConverter {
     BoostConverter(PinName v, PinName i, PinName p);
     float getInputCurrent(void);
     float getInputVoltage(void);
-    void setPWM(float duty);
+    void PO(float vin, float iin);
+    void PID(void);
+    void setDuty(float duty);
+    float getDuty(void);
 };
 
 class Mppt {
   private:
     CAN *can;
     AnalogIn batteryADC;
+    void canLoop(void);
+    bool notParsed(CANMessage msg);
+    Thread thread;
+    volatile bool running;
+  public:
+    mutexVar<float> maxOutputCurrent;
+    mutexVar<float> maxOutputVoltage;
+    mutexVar<uint8_t> mode;
     BoostConverter bc1;
     BoostConverter bc2;
     BoostConverter bc3;
-    Thread thread;
-    volatile bool running;
-    void loop(void);
-    mutexVar<float> maxChargeCurrent;
-    mutexVar<uint8_t> mode;
-    bool notParsed(CANMessage msg);
-    float getBatteryVoltage(void);
-  public:
     Mppt(void);
     ~Mppt(void);
+    float getOutputVoltage(void);
+    float getOutputCurrent(void);
     bool notInit(void);
+    void IPID(void);
+    void VPID(void);
 };

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -8,12 +8,18 @@
 #define MPPT_MOV_ID MPPT_BASE_ID + 10 // max output voltage
 #define MPPT_MIC_ID MPPT_BASE_ID + 11 // max input current
 
+
 class Mppt {
   private:
-    Mutex mutex;
-    uint8_t mode;
-    float maxOutputVoltage;
-    float maxInputCurrent;
+    struct mFloat {
+      Mutex mutex;
+      float value;
+    } maxOutputVoltage, maxInputCurrent;
+
+    struct mU8 {
+      Mutex mutex;
+      uint8_t value;
+    } mode;
   public:
     bool notParsed(CANMessage msg);
 };

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -8,18 +8,23 @@
 #define MPPT_MOV_ID MPPT_BASE_ID + 10 // max output voltage
 #define MPPT_MIC_ID MPPT_BASE_ID + 11 // max input current
 
+template <typename T>
+struct mutexVar {
+  Mutex mutex;
+  T value;
+  void setValue(unsigned char data[8]) {
+    mutex.lock();
+    memcpy(&value, data, sizeof(T));
+    mutex.unlock();
+  }
+};
 
 class Mppt {
   private:
-    struct mFloat {
-      Mutex mutex;
-      float value;
-    } maxOutputVoltage, maxInputCurrent;
+    mutexVar<float> maxOutputVoltage;
+    mutexVar<float> maxInputCurrent;
+    mutexVar<uint8_t> mode;
 
-    struct mU8 {
-      Mutex mutex;
-      uint8_t value;
-    } mode;
   public:
     bool notParsed(CANMessage msg);
 };

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -1,0 +1,18 @@
+#include "mbed.h"
+
+#define MPPT_TX PA_12
+#define MPPT_RX PA_11
+
+#define MPPT_BASE_ID 0x0000
+#define MPPT_MODE_ID MPPT_BASE_ID + 8 // mode
+#define MPPT_MOV_ID MPPT_BASE_ID + 10 // max output voltage
+#define MPPT_MIC_ID MPPT_BASE_ID + 11 // max input current
+
+class Mppt {
+  private:
+    uint8_t mode;
+    uint32_t maxOutputVoltage;
+    uint32_t maxInputCurrent;
+  public:
+    int parseMsg(CANMessage msg);
+};

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -1,22 +1,34 @@
 #include "mbed.h"
-
-#define MPPT_TX PA_12
-#define MPPT_RX PA_11
 #define MPPT_BASE_ID 0x0000
 #define MPPT_MODE_ID MPPT_BASE_ID + 8 // mode
-#define MPPT_MOV_ID MPPT_BASE_ID + 10 // max output voltage
-#define MPPT_MIC_ID MPPT_BASE_ID + 11 // max input current
+#define MPPT_MCC_ID MPPT_BASE_ID + 11 // max charge current
 
+/* This is a struct
+ * which holds a generic typed value
+ * and can only fetch and change value
+ * when mutex is unlocked
+ */
 template <typename T>
 struct mutexVar {
   private:
     Mutex mutex;
-  public:
     T value;
+  public:
     void setValue(unsigned char data[8]) {
       mutex.lock();
       memcpy(&value, data, sizeof(T));
       mutex.unlock();
+    }
+    /* to unlock the mutex before returning,
+     * the value must be copied otherwise
+     * returning the value would
+     * leave the mutex locked
+     */
+    T getValue(unsigned char data[8]) {
+      mutex.lock();
+      T tmp = value;
+      mutex.unlock();
+      return tmp;
     }
 };
 
@@ -26,21 +38,23 @@ class BoostConverter {
     AnalogIn currentADC;
   public:
     BoostConverter(PinName v, PinName i);
-    float voltageIn;
-    float currentIn;
-    void setVoltageIn(void);
-    void setCurrentIn(void);
+    float getChargeCurrent(void);
 };
 
 class Mppt {
   private:
-    BoostConverter BC1;
-    BoostConverter BC2;
-    BoostConverter BC3;
-    mutexVar<float> maxOutputVoltage;
-    mutexVar<float> maxInputCurrent;
+    CAN *can;
+    BoostConverter bc1;
+    BoostConverter bc2;
+    BoostConverter bc3;
+    Thread thread;
+    volatile bool running;
+    void loop(void);
+    mutexVar<float> maxChargeCurrent;
     mutexVar<uint8_t> mode;
-  public:
-    Mppt();
     bool notParsed(CANMessage msg);
+  public:
+    Mppt(void);
+    ~Mppt(void);
+    void init(void);
 };

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -2,7 +2,6 @@
 
 #define MPPT_TX PA_12
 #define MPPT_RX PA_11
-
 #define MPPT_BASE_ID 0x0000
 #define MPPT_MODE_ID MPPT_BASE_ID + 8 // mode
 #define MPPT_MOV_ID MPPT_BASE_ID + 10 // max output voltage
@@ -10,21 +9,38 @@
 
 template <typename T>
 struct mutexVar {
-  Mutex mutex;
-  T value;
-  void setValue(unsigned char data[8]) {
-    mutex.lock();
-    memcpy(&value, data, sizeof(T));
-    mutex.unlock();
-  }
+  private:
+    Mutex mutex;
+  public:
+    T value;
+    void setValue(unsigned char data[8]) {
+      mutex.lock();
+      memcpy(&value, data, sizeof(T));
+      mutex.unlock();
+    }
+};
+
+class BoostConverter {
+  private:
+    AnalogIn voltageADC;
+    AnalogIn currentADC;
+  public:
+    BoostConverter(PinName v, PinName i);
+    float voltageIn;
+    float currentIn;
+    void setVoltageIn(void);
+    void setCurrentIn(void);
 };
 
 class Mppt {
   private:
+    BoostConverter BC1;
+    BoostConverter BC2;
+    BoostConverter BC3;
     mutexVar<float> maxOutputVoltage;
     mutexVar<float> maxInputCurrent;
     mutexVar<uint8_t> mode;
-
   public:
+    Mppt();
     bool notParsed(CANMessage msg);
 };

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -12,7 +12,7 @@ template <typename T>
 struct mutexVar {
   private:
     Mutex mutex;
-    volatile T value;
+    volatile T value = -1;
   public:
     /* volatile cannot be memcpy'd
      * so memcpy to a tmp var

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -10,9 +10,10 @@
 
 class Mppt {
   private:
+    Mutex mutex;
     uint8_t mode;
-    uint32_t maxOutputVoltage;
-    uint32_t maxInputCurrent;
+    float maxOutputVoltage;
+    float maxInputCurrent;
   public:
-    int parseMsg(CANMessage msg);
+    bool notParsed(CANMessage msg);
 };

--- a/include/mppt.h
+++ b/include/mppt.h
@@ -5,7 +5,7 @@
 
 /* This is a struct
  * which holds a generic typed value
- * and can only fetch and change value
+ * and can only change value
  * when mutex is unlocked
  */
 template <typename T>
@@ -40,12 +40,14 @@ struct mutexVar {
 
 class BoostConverter {
   private:
+    PwmOut pwm;
     AnalogIn voltageADC;
     AnalogIn currentADC;
   public:
-    BoostConverter(PinName v, PinName i);
+    BoostConverter(PinName v, PinName i, PinName p);
     float getInputCurrent(void);
     float getInputVoltage(void);
+    void setPWM(float duty);
 };
 
 class Mppt {
@@ -65,5 +67,5 @@ class Mppt {
   public:
     Mppt(void);
     ~Mppt(void);
-    void init(void);
+    bool notInit(void);
 };

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,17 @@
 #include "mbed.h"
+#include "mppt.h"
 
-// main() runs in its own thread in the OS
-int main()
-{
-    while (true) {
+Mppt mppt;
+CAN can(MPPT_RX, MPPT_TX);
 
+int main() {
+  CANMessage msg;
+  while (true) {
+    if (can.read(msg) && mppt.parseMsg(msg)) {
+        printf("No messages received or parsed\n");
     }
+    ThisThread::sleep_for(200);
+  }
+  
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,72 @@
 #include "mbed.h"
 #include "mppt.h"
 
-Mppt mppt;
+static Mppt mppt;
+static int calc_count;
+static float vin[3]; // for bc 1,2, and 3
+static float iin[3];
+static float duty_max[3];
+static int tracking = TRACKING_DELAY;
+
+
+void resetTracking(void) {
+  memset(&vin, 0, 3*sizeof(float));
+  memset(&iin, 0, 3*sizeof(float));
+  calc_count = CALC_INTERVAL;
+}
 
 int main() {
-  if (mppt.notInit()) {
+  resetTracking();
+
+  while (mppt.notInit()) {
     printf("ERROR couldn't init MPPT\n");
+    ThisThread::sleep_for(1s);
   }
-  while (true) {}
+
+  while (true) {
+    if (tracking) {
+      /*
+       * Only start summing the
+       * last SAMPLE_SIZE samples
+       */
+      if (calc_count < SAMPLE_SIZE) {
+        vin[0] += mppt.bc1.getInputVoltage();
+        vin[1] += mppt.bc2.getInputVoltage();
+        vin[2] += mppt.bc3.getInputVoltage();
+
+        iin[0] += mppt.bc1.getInputCurrent();
+        iin[1] += mppt.bc2.getInputCurrent();
+        iin[2] += mppt.bc3.getInputCurrent();
+      }
+
+      if (!calc_count) {
+        mppt.bc1.PO(vin[0],iin[0]);
+        mppt.bc2.PO(vin[1],iin[1]);
+        mppt.bc3.PO(vin[2],iin[2]);
+        resetTracking();
+      }
+      mppt.bc1.PID();
+      mppt.bc2.PID();
+      mppt.bc3.PID();
+
+      if (mppt.getOutputVoltage() > mppt.maxOutputVoltage.getValue() ||
+          (mppt.getOutputCurrent()) > mppt.maxOutputCurrent.getValue()) {
+        tracking--;
+        duty_max[0] = mppt.bc2.getDuty();
+        duty_max[1] = mppt.bc2.getDuty();
+        duty_max[2] = mppt.bc3.getDuty();
+        if (!tracking) resetTracking();
+      } else
+        tracking = TRACKING_DELAY;
+    }
+
+    else {
+      if (mppt.mode.getValue()) mppt.VPID();
+      else mppt.IPID();
+      if (duty_max[0] >= mppt.bc1.getDuty() ||
+          duty_max[1] >= mppt.bc2.getDuty() ||
+          duty_max[2] >= mppt.bc3.getDuty())
+        tracking = TRACKING_DELAY;
+    }
+  }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -7,11 +7,13 @@ CAN can(MPPT_RX, MPPT_TX);
 int main() {
   CANMessage msg;
   while (true) {
-    if (can.read(msg) && mppt.parseMsg(msg)) {
-        printf("No messages received or parsed\n");
+    if (!can.read(msg)) {
+      printf("No messages on CAN bus\n");
+    } else if (mppt.notParsed(msg)) {
+      printf("Error parsing msg\n");
+    } else {
+      printf("Successfully parsed msg!\n");
     }
     ThisThread::sleep_for(200);
   }
-  
 }
-

--- a/main.cpp
+++ b/main.cpp
@@ -2,18 +2,8 @@
 #include "mppt.h"
 
 Mppt mppt;
-CAN can(MPPT_RX, MPPT_TX);
 
 int main() {
-  CANMessage msg;
-  while (true) {
-    if (!can.read(msg)) {
-      printf("No messages on CAN bus\n");
-    } else if (mppt.notParsed(msg)) {
-      printf("Error parsing msg\n");
-    } else {
-      printf("Successfully parsed msg!\n");
-    }
-    ThisThread::sleep_for(200);
-  }
+  mppt.init();
+  while (true) {}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,8 @@
 Mppt mppt;
 
 int main() {
-  mppt.init();
+  if (mppt.notInit()) {
+    printf("ERROR couldn't init MPPT\n");
+  }
   while (true) {}
 }

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os.git#d147abc3e556c58e5e343d34b729bc2192e18bd3

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -24,16 +24,21 @@ BoostConverter::BoostConverter(PinName v, PinName i) : voltageADC(AnalogIn(v)), 
  * storing the value, because
  * the value could change quickly
  */
-float BoostConverter::getChargeCurrent(void) {
+float BoostConverter::getInputCurrent(void) {
   return currentADC.read_voltage();
 }
-
+float BoostConverter::getInputVoltage(void) {
+  return voltageADC.read_voltage();
+}
+float Mppt::getBatteryVoltage(void) {
+  return batteryADC.read_voltage();
+}
 
 /* void constructor, because
  * we already know exactly
  * what pins the Mppt will use
  */
-Mppt::Mppt(void) : bc1(BoostConverter(PA_7, PA_6)), bc2(BoostConverter (PA_5, PA_4)), bc3(BoostConverter (PA_3, PA_2)), can(&c) {}
+Mppt::Mppt(void) : batteryADC(AnalogIn(PB_0)), bc1(BoostConverter(PA_7, PA_6)), bc2(BoostConverter (PA_5, PA_4)), bc3(BoostConverter (PA_3, PA_2)), can(&c) {}
 
 /* kill the thread and join
  * before destroying the object
@@ -43,7 +48,7 @@ Mppt::~Mppt(void) {
   thread.join();
 }
 
-/* Seperate function to init
+/* Separate function to init
  *
  * "Eric taught me"
  * in Kanye Blame Game woman voice

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -1,26 +1,88 @@
 #include "mppt.h"
 #include "mbed.h"
 
+/* static CAN bus means
+ * it will last the whole program 
+ * 
+ * CAN objects are not copyable 
+ * meaning they cannot be created
+ * like the AnalogIn and BoostConverter,
+ * then copied into the class,
+ * they must be passed by reference 
+ *
+ * a static CAN object is better than
+ * using the new keyword 
+ * to create it on the heap */
+static CAN c(PA_11, PA_12); 
+
+/* BoostConverter will read the ADC
+ * for current in and voltage in
+ */
 BoostConverter::BoostConverter(PinName v, PinName i) : voltageADC(AnalogIn(v)), currentADC(AnalogIn(i)) {}
 
-void BoostConverter::setCurrentIn(void) {
-  currentIn = currentADC.read_voltage();
-}
-void BoostConverter::setVoltageIn(void) {
-  voltageIn = voltageADC.read_voltage();
+/* directly read the pin rather than
+ * storing the value, because
+ * the value could change quickly
+ */
+float BoostConverter::getChargeCurrent(void) {
+  return currentADC.read_voltage();
 }
 
-Mppt::Mppt() : BC1(BoostConverter(PA_7, PA_6)), BC2(BoostConverter (PA_5, PA_4)), BC3(BoostConverter (PA_3, PA_2)) {}
 
+/* void constructor, because
+ * we already know exactly
+ * what pins the Mppt will use
+ */
+Mppt::Mppt(void) : bc1(BoostConverter(PA_7, PA_6)), bc2(BoostConverter (PA_5, PA_4)), bc3(BoostConverter (PA_3, PA_2)), can(&c) {}
+
+/* kill the thread and join
+ * before destroying the object
+ */
+Mppt::~Mppt(void) {
+  running=false;
+  thread.join();
+}
+
+/* Seperate function to init
+ *
+ * "Eric taught me"
+ * in Kanye Blame Game woman voice
+ */
+void Mppt::init(void) {
+  running = true;
+  thread.start(callback(this, &Mppt::loop));
+}
+
+/* Function to pass to thread
+ *
+ * Checks the CAN bus
+ * and parses the msg
+ */
+void Mppt::loop(void) {
+  CANMessage msg;
+  while (running) {
+    if (!can->read(msg)) {
+      printf("No messages on CAN bus\n");
+    } else if (notParsed(msg)) {
+      printf("Error parsing msg\n");
+    } else {
+      printf("Successfully parsed msg!\n");
+    }
+    ThisThread::sleep_for(200ms);
+  }
+}
+
+/* Parses msg and returns
+ * true if the message was
+ * not parsed.
+ * Makes sense in
+ * loop func logic
+ */
 bool Mppt::notParsed(CANMessage msg) {
   switch (msg.id) {
 
-    case MPPT_MOV_ID:
-      maxOutputVoltage.setValue(msg.data);
-      break;
-
-    case MPPT_MIC_ID:
-      maxInputCurrent.setValue(msg.data);
+    case MPPT_MCC_ID:
+      maxChargeCurrent.setValue(msg.data);
       break;
 
     case MPPT_MODE_ID:

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -6,26 +6,28 @@ bool Mppt::notParsed(CANMessage msg) {
   switch (msg.id) {
 
     case MPPT_MOV_ID:
-      this->mutex.lock();
-      memcpy(&maxOutputVoltage, msg.data, 4);
-      printf("Set Max Output Voltage to %.6f\n",maxOutputVoltage);
+      maxOutputVoltage.mutex.lock();
+      memcpy(&maxOutputVoltage.value, msg.data, 4);
+      printf("Set Max Output Voltage to %.6f\n",maxOutputVoltage.value);
+      maxOutputVoltage.mutex.unlock();
       break;
 
     case MPPT_MIC_ID:
-      this->mutex.lock();
-      memcpy(&maxInputCurrent, msg.data, 4);
-      printf("Set Max Input Current to %.6f\n",maxInputCurrent);
+      maxInputCurrent.mutex.lock();
+      memcpy(&maxInputCurrent.value, msg.data, 4);
+      printf("Set Max Input Current to %.6f\n",maxInputCurrent.value);
+      maxInputCurrent.mutex.unlock();
       break;
 
     case MPPT_MODE_ID:
-      this->mutex.lock();
-      memcpy(&mode, msg.data, 1);
-      printf("Set Mode to %u\n",mode);
+      mode.mutex.lock();
+      memcpy(&mode.value, msg.data, 1);
+      printf("Set Mode to %u\n",mode.value);
+      mode.mutex.unlock();
       break;
 
     default:
       return true;
   }
-  this->mutex.unlock();
   return false;
 }

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -8,7 +8,6 @@
  * meaning they cannot copied into the class,
  * like the AnalogIn and BoostConverter can,
  * they must be passed by reference 
- * Because of this I'll pass everything by reference
  *
  * a static object is better than
  * using the new keyword 
@@ -19,7 +18,7 @@ static CAN c(PA_11, PA_12);
  * for current in and voltage in
  */
 BoostConverter::BoostConverter(PinName v, PinName i, PinName p) : voltageADC(AnalogIn(v)), currentADC(AnalogIn(i)), pwm(PwmOut(p)) {
-  pwm.period_us(12.5); // 12.5uS is 80000hZ
+  pwm.period_us(12); // 12uS is 83333hZ
 }
 
 /*
@@ -62,7 +61,7 @@ Mppt::~Mppt(void) {
 
 /* Separate function to init
  *
- * "Eric taught me"
+ * "Eudlis taught me"
  * in Kanye Blame Game woman voice
  *
  * running is used in the loop func

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -6,24 +6,15 @@ bool Mppt::notParsed(CANMessage msg) {
   switch (msg.id) {
 
     case MPPT_MOV_ID:
-      maxOutputVoltage.mutex.lock();
-      memcpy(&maxOutputVoltage.value, msg.data, 4);
-      printf("Set Max Output Voltage to %.6f\n",maxOutputVoltage.value);
-      maxOutputVoltage.mutex.unlock();
+      maxOutputVoltage.setValue(msg.data);
       break;
 
     case MPPT_MIC_ID:
-      maxInputCurrent.mutex.lock();
-      memcpy(&maxInputCurrent.value, msg.data, 4);
-      printf("Set Max Input Current to %.6f\n",maxInputCurrent.value);
-      maxInputCurrent.mutex.unlock();
+      maxInputCurrent.setValue(msg.data);
       break;
 
     case MPPT_MODE_ID:
-      mode.mutex.lock();
-      memcpy(&mode.value, msg.data, 1);
-      printf("Set Mode to %u\n",mode.value);
-      mode.mutex.unlock();
+      mode.setValue(msg.data);
       break;
 
     default:

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -1,6 +1,16 @@
 #include "mppt.h"
 #include "mbed.h"
 
+BoostConverter::BoostConverter(PinName v, PinName i) : voltageADC(AnalogIn(v)), currentADC(AnalogIn(i)) {}
+
+void BoostConverter::setCurrentIn(void) {
+  currentIn = currentADC.read_voltage();
+}
+void BoostConverter::setVoltageIn(void) {
+  voltageIn = voltageADC.read_voltage();
+}
+
+Mppt::Mppt() : BC1(BoostConverter(PA_7, PA_6)), BC2(BoostConverter (PA_5, PA_4)), BC3(BoostConverter (PA_3, PA_2)) {}
 
 bool Mppt::notParsed(CANMessage msg) {
   switch (msg.id) {

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -1,0 +1,22 @@
+#include "mppt.h"
+#include "mbed.h"
+
+int Mppt::parseMsg(CANMessage msg) {
+  switch (msg.id) {
+    case MPPT_MOV_ID:
+      memcpy(&maxOutputVoltage, msg.data, 4);
+      printf("Set Max Output Voltage to %u\n",maxOutputVoltage);
+      break;
+    case MPPT_MIC_ID:
+      memcpy(&maxInputCurrent, msg.data, 4);
+      printf("Set Max Input Current to %u\n",maxInputCurrent);
+      break;
+    case MPPT_MODE_ID:
+      memcpy(&mode, msg.data, 1);
+      printf("Set Mode to %u\n",mode);
+      break;
+    default:
+      return 1;
+  }
+  return 0;
+}

--- a/src/mppt.cpp
+++ b/src/mppt.cpp
@@ -1,22 +1,31 @@
 #include "mppt.h"
 #include "mbed.h"
 
-int Mppt::parseMsg(CANMessage msg) {
+
+bool Mppt::notParsed(CANMessage msg) {
   switch (msg.id) {
+
     case MPPT_MOV_ID:
+      this->mutex.lock();
       memcpy(&maxOutputVoltage, msg.data, 4);
-      printf("Set Max Output Voltage to %u\n",maxOutputVoltage);
+      printf("Set Max Output Voltage to %.6f\n",maxOutputVoltage);
       break;
+
     case MPPT_MIC_ID:
+      this->mutex.lock();
       memcpy(&maxInputCurrent, msg.data, 4);
-      printf("Set Max Input Current to %u\n",maxInputCurrent);
+      printf("Set Max Input Current to %.6f\n",maxInputCurrent);
       break;
+
     case MPPT_MODE_ID:
+      this->mutex.lock();
       memcpy(&mode, msg.data, 1);
       printf("Set Mode to %u\n",mode);
       break;
+
     default:
-      return 1;
+      return true;
   }
-  return 0;
+  this->mutex.unlock();
+  return false;
 }


### PR DESCRIPTION
Requirements
--
- [X] Receive CAN messages (Nucleo TX on pin PA12, RX on PA11) from the LV Beaglebone indicating:

  - MPPT mode or battery charge mode
  - Maximum charge current (when in charge mode)

- [ ] Perform a periodic health indicator (may be a CAN message checksum/ message received indicator) that will open the battery contactor if not received after period of time

- [x] Read ADCs on pins PA7, PA5, and PA3 and derive the String input current based on the voltage on these pins

- [X] Read ADCs on pins PA6, PA4, and PA1 and derive the String input voltage based on the voltage on these pins

- [x] Read ADC on pin PB0 to derive the battery voltage based on the voltage from this pin

- [x] Deliver a ~80,000hz PWM signal on pins PA9, PA10, and PA8.

- [x] Perform MPPT tracking using a perturb and observe algorithm implementing a PID control scheme that modifies the PWM duty cycle to deliver desired output current to the battery (maximum possible in MPPT mode, prescribed current in battery charge mode).

  - String input current, string input voltage, and pack voltage is derived from ADC input values

  - Converter output currents per string (Iout) is solved for using Pin = Pout: Iin*Vin =Vout *Iout.

  - Battery input current is a summation of calculated converter output currents.

  - NOTE: PWM signal must be OPPOSITE OF INDENDED DUTY CYCLE. Ex: For a desired 80% duty cycle, a 20% DC should be applied. This is due to the inverting nature of IN_L, which drives the boost FET.

Nice to haves
--
- [ ] Telemetry back on the CANbus to the Beaglebone indicating measured values (string input voltage, input current, output current)

- [ ] Temperature monitoring from thermistors on pin PA0.

  - There is one thermistor per boost converter string (3 total), and these three signals are muxed through a discrete device, whose output is selected by Nucleo GPIO pins PB4 & PB5.